### PR TITLE
Fix AuthContext import paths

### DIFF
--- a/smart-meeting-frontend/src/Component/Login.jsx
+++ b/smart-meeting-frontend/src/Component/Login.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { AuthContext } from '../contexts/AuthContext';
+import { AuthContext } from '../contexts/AuthContext.jsx';
 import './../App.css';
 
 function Login() {

--- a/smart-meeting-frontend/src/pages/Dashboard.jsx
+++ b/smart-meeting-frontend/src/pages/Dashboard.jsx
@@ -1,7 +1,7 @@
 // C:\Users\Youssef Hindawi\smart-meeting-room1\smart-meeting-frontend\src\pages\Dashboard.jsx
 import { useContext } from 'react';
 import { Link } from 'react-router-dom';
-import { AuthContext } from '../contexts/AuthContext';
+import { AuthContext } from '../contexts/AuthContext.jsx';
 import RoomList from '../components/RoomList';
 
 export default function Dashboard() {

--- a/smart-meeting-frontend/src/pages/LoginPage.jsx
+++ b/smart-meeting-frontend/src/pages/LoginPage.jsx
@@ -1,6 +1,6 @@
 // src/pages/LoginPage.jsx
 import { useState, useContext } from 'react';
-import { AuthContext } from '../contexts/AuthContext';
+import { AuthContext } from '../contexts/AuthContext.jsx';
 
 export default function LoginPage() {
   const { signIn } = useContext(AuthContext);


### PR DESCRIPTION
## Summary
- fix imports in dashboard, login page, and login component to reference `AuthContext.jsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `php artisan test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_b_688b5b20a99c832d919aef0c93ca9547