### PR TITLE
refactor: use shared api instance

### DIFF
--- a/smart-meeting-frontend/src/AdminDashboard/AddUsers.jsx
+++ b/smart-meeting-frontend/src/AdminDashboard/AddUsers.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
-import axios from "axios";
+import api from "../api";
 
-const apiBase = "http://localhost:8000/api/users";
+const apiBase = "/users";
 
 export default function UsersManager() {
   const [users, setUsers] = useState([]);
@@ -21,7 +21,7 @@ export default function UsersManager() {
 
   const fetchUsers = async () => {
     try {
-      const res = await axios.get(apiBase);
+      const res = await api.get(apiBase);
       setUsers(res.data);
     } catch (err) {
       console.error("Failed to fetch users:", err);
@@ -64,9 +64,9 @@ export default function UsersManager() {
       if (isEditing) {
         const payload = { ...formData };
         if (!payload.password) delete payload.password;
-        await axios.put(`${apiBase}/${formData.id}`, payload);
+        await api.put(`${apiBase}/${formData.id}`, payload);
       } else {
-        await axios.post(apiBase, formData);
+        await api.post(apiBase, formData);
       }
       fetchUsers();
       resetForm();
@@ -79,7 +79,7 @@ export default function UsersManager() {
   // NEW: Confirm delete inside modal
   const confirmDelete = async () => {
     try {
-      await axios.delete(`${apiBase}/${deleteUserId}`);
+      await api.delete(`${apiBase}/${deleteUserId}`);
       setUsers((prev) => prev.filter((user) => user.id !== deleteUserId));
     } catch (err) {
       console.error("Failed to delete user:", err);

--- a/smart-meeting-frontend/src/AdminDashboard/AdminDashboard.jsx
+++ b/smart-meeting-frontend/src/AdminDashboard/AdminDashboard.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import axios from "axios";
+import api from "../api";
 import { FaCalendarAlt, FaVideo, FaFileAlt } from "react-icons/fa";
 import Topbar from "./Topbar";
 import QuickActions from "./QuickActions";
@@ -12,7 +12,7 @@ export default function AdminDashboard() {
   const [contacts, setContacts] = useState([]);
 
   useEffect(() => {
-    axios.get("http://localhost:8000/api/contact")
+    api.get("/contact")
       .then((res) => {
         setContacts(res.data);
       })

--- a/smart-meeting-frontend/src/AdminDashboard/AnalyticsCard.jsx
+++ b/smart-meeting-frontend/src/AdminDashboard/AnalyticsCard.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import axios from "axios";
+import api from "../api";
 
 const AnalyticsCard = ({ title, chartData }) => {
   return (
@@ -28,8 +28,8 @@ export default function RoomUsageAnalytics() {
     const fetchData = async () => {
       try {
         const [roomsRes, meetingsRes] = await Promise.all([
-          axios.get("http://localhost:8000/api/rooms"),
-          axios.get("http://localhost:8000/api/meetings"),
+          api.get("/rooms"),
+          api.get("/meetings"),
         ]);
         setRooms(roomsRes.data);
         setMeetings(meetingsRes.data);

--- a/smart-meeting-frontend/src/AdminDashboard/ManageRooms.jsx
+++ b/smart-meeting-frontend/src/AdminDashboard/ManageRooms.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { FaEdit, FaPlus, FaTrash } from "react-icons/fa";
-import axios from "axios";
+import api from "../api";
 
 export default function ManageRooms() {
   const [rooms, setRooms] = useState([]);
@@ -18,10 +18,10 @@ export default function ManageRooms() {
     is_active: true,
   });
 
-  const apiBase = "http://localhost:8000/api/rooms";
+  const apiBase = "/rooms";
 
   useEffect(() => {
-    axios
+    api
       .get(apiBase)
       .then((res) => setRooms(res.data))
       .catch((err) => console.error("Failed to fetch rooms:", err));
@@ -79,12 +79,12 @@ export default function ManageRooms() {
 
     try {
       if (editRoom) {
-        const res = await axios.put(`${apiBase}/${editRoom.id}`, payload);
+        const res = await api.put(`${apiBase}/${editRoom.id}`, payload);
         setRooms((prev) =>
           prev.map((r) => (r.id === editRoom.id ? res.data : r))
         );
       } else {
-        const res = await axios.post(apiBase, payload);
+        const res = await api.post(apiBase, payload);
         setRooms((prev) => [...prev, res.data]);
       }
       setModalOpen(false);
@@ -106,7 +106,7 @@ export default function ManageRooms() {
   // Proceed with deletion
   const proceedDelete = async () => {
     try {
-      await axios.delete(`${apiBase}/${deleteConfirmRoomId}`);
+      await api.delete(`${apiBase}/${deleteConfirmRoomId}`);
       setRooms((prev) => prev.filter((r) => r.id !== deleteConfirmRoomId));
     } catch (err) {
       console.error("Failed to delete room:", err);

--- a/smart-meeting-frontend/src/AdminDashboard/MeetingList.jsx
+++ b/smart-meeting-frontend/src/AdminDashboard/MeetingList.jsx
@@ -1,12 +1,12 @@
 // Example: MeetingList.jsx
 import React, { useEffect, useState } from "react";
-import axios from "axios";
+import api from "../api";
 
 export default function MeetingList() {
   const [meetings, setMeetings] = useState([]);
 
   useEffect(() => {
-    axios.get("http://localhost:8000/api/meetings") // your API endpoint
+    api.get("/meetings") // your API endpoint
       .then(res => {
         setMeetings(res.data);
       })

--- a/smart-meeting-frontend/src/AdminDashboard/RoomCalendar.jsx
+++ b/smart-meeting-frontend/src/AdminDashboard/RoomCalendar.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Calendar, Views } from "react-big-calendar";
 import { localizer } from "./calendarSetup";
-import axios from "axios";
+import api from "../api";
 
 const roomColors = [
   "#7d65fb",
@@ -26,8 +26,8 @@ const RoomCalendar = () => {
   const [view, setView] = useState(Views.MONTH);
 
   useEffect(() => {
-    axios.get("http://localhost:8000/api/rooms").then(res => setRooms(res.data));
-    axios.get("http://localhost:8000/api/meetings").then(res => setMeetings(res.data));
+    api.get("/rooms").then(res => setRooms(res.data));
+    api.get("/meetings").then(res => setMeetings(res.data));
   }, []);
 
   // Map room name to color

--- a/smart-meeting-frontend/src/Component/Navbar.jsx
+++ b/smart-meeting-frontend/src/Component/Navbar.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
-import axios from "axios";
+import api from "../api";
 
 function Navbar() {
   const [showContactForm, setShowContactForm] = useState(false);
@@ -23,7 +23,7 @@ function Navbar() {
     setStatus("");
 
     try {
-      await axios.post("http://localhost:8000/api/contact", formData);
+      await api.post("/contact", formData);
       setStatus("Message sent successfully!");
       setFormData({ name: "", email: "", message: "" });
       setTimeout(() => {


### PR DESCRIPTION
## Summary
- replace direct axios imports with shared api instance for automatic auth and CSRF headers across Navbar, MeetingList, RoomCalendar, AnalyticsCard, AdminDashboard, AddUsers, and ManageRooms

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: /src/AdminDashboard/MinutesEditor.jsx - 'data' is assigned a value but never used)*
- `npx eslint src/Component/Navbar.jsx src/AdminDashboard/MeetingList.jsx src/AdminDashboard/RoomCalendar.jsx src/AdminDashboard/AnalyticsCard.jsx src/AdminDashboard/AdminDashboard.jsx src/AdminDashboard/AddUsers.jsx src/AdminDashboard/ManageRooms.jsx`


------
https://chatgpt.com/codex/tasks/task_b_689766d29470832d876c5bc4461b0531